### PR TITLE
Рефакторинг: Винесено хук useMarkdown та компонент MarkdownPreview

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,34 +1,18 @@
-// src/App.jsx
-
-import { useState, useEffect } from 'react';
 import './App.css';
-import { parseMarkdown } from './utils/markdown';
-import { getMarkdown, saveMarkdown } from './utils/storage';
+import { useMarkdown } from '../hooks/useMarkdown';
+import MarkdownPreview from './MarkdownPreview';
 
 function App() {
-    const [markdown, setMarkdown] = useState('');
+    const { markdown, updateMarkdown } = useMarkdown();
 
-    useEffect(() => {
-        const stored = getMarkdown();
-        setMarkdown(stored);
-    }, []);
-
-    const handleChange = (e) => {
-        const value = e.target.value;
-        setMarkdown(value);
-        saveMarkdown(value);
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        updateMarkdown(e.target.value);
     };
 
     return (
         <div className="App">
-      <textarea
-          value={markdown}
-          onChange={handleChange}
-      />
-            <div
-                className="preview"
-                dangerouslySetInnerHTML={{ __html: parseMarkdown(markdown) }}
-            />
+            <textarea value={markdown} onChange={handleChange} />
+            <MarkdownPreview content={markdown} />
         </div>
     );
 }

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { parseMarkdown } from '../utils/markdown';
+
+interface Props {
+    content: string;
+}
+
+const MarkdownPreview: React.FC<Props> = ({ content }) => {
+    return (
+        <div
+            className="preview"
+            dangerouslySetInnerHTML={{ __html: parseMarkdown(content) }}
+        />
+    );
+};
+
+export default MarkdownPreview;

--- a/src/hooks/useMarkdown.ts
+++ b/src/hooks/useMarkdown.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+import { getMarkdown, saveMarkdown } from '../utils/storage';
+
+export const useMarkdown = () => {
+    const [markdown, setMarkdown] = useState('');
+
+    useEffect(() => {
+        const stored = getMarkdown();
+        setMarkdown(stored);
+    }, []);
+
+    const updateMarkdown = (value: string) => {
+        setMarkdown(value);
+        saveMarkdown(value);
+    };
+
+    return { markdown, updateMarkdown };
+};


### PR DESCRIPTION
Цей Pull Request вирішує проблему порушення принципу єдиної відповідальності (SRP) у файлі App.tsx. Раніше компонент одночасно:

- зберігав і завантажував Markdown з localStorage,
- керував станом,
- та рендерив розмітку.

 Що було змінено:

- Створено кастомний хук useMarkdown — для винесення логіки завантаження та збереження markdown.
- Створено окремий компонент MarkdownPreview — для парсингу markdown у HTML та відображення результату.
- Компонент App.tsx очищено від зайвої логіки — тепер він лише керує інтерфейсом.
Переваги:

- Покращено читабельність та структуру коду.
- Кожен компонент/файл тепер виконує одну чітку відповідальність.
- Спрощено подальше тестування та масштабування.